### PR TITLE
Fix signals used in elaboration

### DIFF
--- a/pid_controller.vhd
+++ b/pid_controller.vhd
@@ -94,12 +94,18 @@ architecture behavioral of pid_controller is
 
     -- Stage 2: Multiply PID coefficients.
     signal s2_tvalid: std_logic;
-    signal s2_p_tdata: sfixed(sfixed_high(s1_p_tdata, '*', kp_fixed)
-        downto sfixed_low(s1_p_tdata, '*', kp_fixed));
-    signal s2_i_tdata: sfixed(sfixed_high(s1_i_tdata, '*', ki_fixed)
-        downto sfixed_low(s1_i_tdata, '*', ki_fixed));
-    signal s2_d_tdata: sfixed(sfixed_high(s1_d_tdata, '*', kd_fixed)
-        downto sfixed_low(s1_d_tdata, '*', kd_fixed));
+    signal s2_p_tdata: sfixed(
+        sfixed_high(s1_p_tdata'high, s1_p_tdata'low, '*', kp_fixed'high, kp_fixed'low)
+        downto
+        sfixed_low(s1_p_tdata'high, s1_p_tdata'low, '*', kp_fixed'high, kp_fixed'low));
+    signal s2_i_tdata: sfixed(
+        sfixed_high(s1_i_tdata'high, s1_i_tdata'low, '*', ki_fixed'high, ki_fixed'low)
+        downto
+        sfixed_low(s1_i_tdata'high, s1_i_tdata'low, '*', ki_fixed'high, ki_fixed'low));
+    signal s2_d_tdata: sfixed(
+        sfixed_high(s1_d_tdata'high, s1_d_tdata'low, '*', kd_fixed'high, kd_fixed'low)
+        downto
+        sfixed_low(s1_d_tdata'high, s1_d_tdata'low, '*', kd_fixed'high, kd_fixed'low));
 
     -- Stage 3a: Sum P and I terms.
     --


### PR DESCRIPTION
Fixes an issue with GHDL 6.0.0 where the use of certain overloads for `sfixed_high()` and `sfixed_low()` were not allowed during elaboration. The solution uses the more verbose overload in which the ranges are specified explicitly by signal attributes.

Closes #10